### PR TITLE
Add packaging ingredient for new users

### DIFF
--- a/controllers/recetasController.js
+++ b/controllers/recetasController.js
@@ -1,6 +1,6 @@
 // controllers/recetaController.js
 
-const recetaService = require('../services/recetaService');
+const recetaService = require('../services/recetaServices');
 const { obtenerUserIdDesdeRequest } = require('../middlewares/authMiddleware');
 
 exports.obtenerRecetas = async (req, res) => {
@@ -68,5 +68,14 @@ exports.eliminarReceta = async (req, res) => {
     res.json({ message: 'Receta eliminada exitosamente' });
   } catch (error) {
     res.status(400).json({ error: error.message });
+  }
+};
+
+// Creación automática de receta con ingrediente Packaging
+exports.crearRecetaAutomatica = async (idTorta, userId) => {
+  try {
+    await recetaService.crearRecetaAutomatica(idTorta, userId);
+  } catch (error) {
+    throw new Error(error.message);
   }
 };

--- a/services/recetaServices.js
+++ b/services/recetaServices.js
@@ -104,3 +104,28 @@ exports.eliminarReceta = async ({ ID_TORTA, userId }) => {
   await receta.destroy();
   await actualizarListaPrecios();
 };
+
+// Crear receta automática con el ingrediente "Packaging"
+exports.crearRecetaAutomatica = async (idTorta, userId) => {
+  let packaging = await Ingrediente.findOne({
+    where: { nombre: 'Packaging', id_usuario: userId }
+  });
+
+  if (!packaging) {
+    packaging = await Ingrediente.create({
+      nombre: 'Packaging',
+      unidad_Medida: 'unidad',
+      tamano_Paquete: 1,
+      costo: 1000,
+      CantidadStock: 0,
+      id_usuario: userId
+    });
+  }
+
+  await Receta.create({
+    ID_TORTA: idTorta,
+    ID_INGREDIENTE: packaging.id,
+    cantidad: 1,
+    id_usuario: userId
+  });
+};

--- a/services/tortaServices.js
+++ b/services/tortaServices.js
@@ -18,8 +18,8 @@ exports.crearTorta = async ({ nombre_torta, descripcion_torta, imagen, userId })
     id_usuario: userId
   });
 
-  // Crear receta automática
-  await crearRecetaAutomatica(tortaNueva.ID_TORTA, userId, nombre_torta);
+  // Crear receta automática con Packaging
+  await crearRecetaAutomatica(tortaNueva.ID_TORTA, userId);
 
   // Calcular costo de receta automática
   const costoRecetaAutomatica = await calcularCostoTotalReceta(tortaNueva.ID_TORTA);

--- a/services/userService.js
+++ b/services/userService.js
@@ -1,6 +1,7 @@
 const bcrypt = require('bcrypt');
 const jwt = require('jsonwebtoken');
 const User = require('../models/User');
+const Ingrediente = require('../models/Ingrediente');
 const nodemailer = require('nodemailer');
 require('dotenv').config();
 
@@ -31,7 +32,18 @@ exports.loginUser = async ({ email, contrasena }) => {
 // Registro
 exports.createUser = async ({ nombre, email, contrasena }) => {
   const hashedPassword = await bcrypt.hash(contrasena, 10);
-  return await User.create({ nombre, email, contrasena: hashedPassword });
+  const user = await User.create({ nombre, email, contrasena: hashedPassword });
+
+  await Ingrediente.create({
+    nombre: 'Packaging',
+    unidad_Medida: 'unidad',
+    tamano_Paquete: 1,
+    costo: 1000,
+    CantidadStock: 0,
+    id_usuario: user.id
+  });
+
+  return user;
 };
 
 // Listado de usuarios


### PR DESCRIPTION
## Summary
- create a dummy `Packaging` ingredient when registering a user
- make cake creation automatically generate a recipe with this ingredient

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685c9e529eb4832b8ad85a30283ed6f7