### PR TITLE
Fix JWT secret usage

### DIFF
--- a/controllers/listaPreciosController.js
+++ b/controllers/listaPreciosController.js
@@ -11,7 +11,7 @@ const obtenerUserId = (req) => {
   }
 
   const token = req.headers.authorization.split(' ')[1];
-  const decoded = jwt.verify(token, 'secreto');
+  const decoded = jwt.verify(token, process.env.JWT_SECRET);
   return decoded.userId;
 };
 


### PR DESCRIPTION
## Summary
- load JWT secret from `process.env.JWT_SECRET` in `listaPreciosController`

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_687d62646c98832b81fb92409e998592