### PR TITLE
Configuración de CORS y puerto por variables de entorno

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,33 @@
+# CostoSmart Backend
+
+Este proyecto es el servidor de la aplicación **CostoSmart**. Utiliza Express y Sequelize para exponer una API REST.
+
+## Variables de entorno
+
+El servidor utiliza variables de entorno que pueden declararse en un archivo `.env` en la raíz del proyecto. Para configurar el CORS y el puerto del servidor se emplean las siguientes variables:
+
+- `CORS_ORIGIN`: origen permitido para las solicitudes CORS. Si no se define, se permite cualquier origen (útil para desarrollo).
+- `PORT`: puerto en el que se ejecuta el servidor. Por defecto `3001`.
+
+Ejemplo de archivo `.env`:
+
+```dotenv
+CORS_ORIGIN=http://localhost:3000
+PORT=3001
+DB_HOST=localhost
+DB_PORT=3306
+DB_USER=root
+DB_PASS=tu_contrasena
+DB_NAME=costo_smart
+```
+
+## Uso
+
+Instala las dependencias y ejecuta el servidor con:
+
+```bash
+npm install
+npm start
+```
+
+Esto levantará la API usando los valores de las variables de entorno que hayas configurado.

--- a/server.js
+++ b/server.js
@@ -23,13 +23,16 @@ db.authenticate()
 
 
 
+// Leer origen permitido desde variable de entorno, por defecto abierto
+const corsOrigin = process.env.CORS_ORIGIN || '*';
+
 const corsOptions = {
-    origin: '*', // <- PERMITE TODOS
+    origin: corsOrigin,
     methods: ['GET', 'POST', 'PUT', 'DELETE', 'OPTIONS'],
     allowedHeaders: ['Content-Type', 'Authorization'],
   };
 
-  app.use(cors(corsOptions));
+app.use(cors(corsOptions));
 app.options('*', cors(corsOptions)); // <-- NECESARIO para solicitudes preflight
 
 
@@ -65,7 +68,7 @@ app.use('/lista_precios', listaPreciosRoutes);
 app.use('/uploads', express.static(path.join(__dirname, 'uploads')));
 
 // Puerto del servidor
-const PORT = 3001;
+const PORT = process.env.PORT || 3001;
 
 app.listen(PORT, () => {
   console.log(`Servidor corriendo en el puerto ${PORT}`);


### PR DESCRIPTION
## Summary
- make CORS origin configurable via `CORS_ORIGIN`
- make port configurable via `PORT`
- add documentation describing how to set these environment variables

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_687d635f02a8832b843a04839c3df76f