### PR TITLE
Fix error codes in catch blocks

### DIFF
--- a/controllers/ingredienteController.js
+++ b/controllers/ingredienteController.js
@@ -7,7 +7,7 @@ exports.obtenerIngredientes = async (req, res) => {
     const ingredientes = await ingredienteService.obtenerIngredientes(userId);
     res.json({ success: true, ingredientes });
   } catch (error) {
-    res.status(400).json({ error: error.message });
+    res.status(500).json({ error: error.message });
   }
 };
 
@@ -20,7 +20,7 @@ exports.guardarIngrediente = async (req, res) => {
 
     res.json({ success: true });
   } catch (error) {
-    res.status(400).json({ error: error.message });
+    res.status(500).json({ error: error.message });
   }
 };
 
@@ -43,7 +43,7 @@ exports.editarIngrediente = async (req, res) => {
 
     res.json({ success: true });
   } catch (error) {
-    res.status(400).json({ error: error.message });
+    res.status(500).json({ error: error.message });
   }
 };
 
@@ -53,7 +53,7 @@ exports.obtenerIngredientesMenosStock = async (req, res) => {
     const ingredientes = await ingredienteService.obtenerIngredientesMenosStock(userId);
     res.json(ingredientes);
   } catch (error) {
-    res.status(400).json({ error: error.message });
+    res.status(500).json({ error: error.message });
   }
 };
 
@@ -66,6 +66,6 @@ exports.eliminarIngrediente = async (req, res) => {
 
     res.json({ success: true });
   } catch (error) {
-    res.status(400).json({ error: error.message });
+    res.status(500).json({ error: error.message });
   }
 };

--- a/controllers/recetasController.js
+++ b/controllers/recetasController.js
@@ -9,7 +9,7 @@ exports.obtenerRecetas = async (req, res) => {
     const recetas = await recetaService.obtenerRecetasPorUsuario(userId);
     res.json(recetas);
   } catch (error) {
-    res.status(400).json({ error: error.message });
+    res.status(500).json({ error: error.message });
   }
 };
 
@@ -28,7 +28,7 @@ exports.crearOEditarReceta = async (req, res) => {
 
     res.json({ success: true });
   } catch (error) {
-    res.status(400).json({ error: error.message });
+    res.status(500).json({ error: error.message });
   }
 };
 
@@ -41,7 +41,7 @@ exports.agregarRelacion = async (req, res) => {
 
     res.json({ message: 'Nueva relación agregada exitosamente' });
   } catch (error) {
-    res.status(400).json({ error: error.message });
+    res.status(500).json({ error: error.message });
   }
 };
 
@@ -54,7 +54,7 @@ exports.eliminarAsignacion = async (req, res) => {
 
     res.json({ message: 'Asignación de receta eliminada exitosamente' });
   } catch (error) {
-    res.status(400).json({ error: error.message });
+    res.status(500).json({ error: error.message });
   }
 };
 
@@ -67,7 +67,7 @@ exports.eliminarReceta = async (req, res) => {
 
     res.json({ message: 'Receta eliminada exitosamente' });
   } catch (error) {
-    res.status(400).json({ error: error.message });
+    res.status(500).json({ error: error.message });
   }
 };
 

--- a/controllers/tortaController.js
+++ b/controllers/tortaController.js
@@ -14,7 +14,7 @@ exports.crearTorta = async (req, res) => {
     res.json({ success: true, torta });
   } catch (error) {
     console.error('Error al crear la torta:', error);
-    res.status(400).json({ error: error.message });
+    res.status(500).json({ error: error.message });
   }
 };
 
@@ -24,7 +24,7 @@ exports.obtenerTortas = async (req, res) => {
     const tortas = await tortaService.obtenerTortasPorUsuario(userId);
     res.json(tortas);
   } catch (error) {
-    res.status(400).json({ error: error.message });
+    res.status(500).json({ error: error.message });
   }
 };
 
@@ -39,7 +39,7 @@ exports.editarTorta = async (req, res) => {
     res.json({ success: true, torta });
   } catch (error) {
     console.error('Error al editar la torta:', error);
-    res.status(400).json({ error: error.message });
+    res.status(500).json({ error: error.message });
   }
 };
 
@@ -52,6 +52,6 @@ exports.eliminarTorta = async (req, res) => {
     res.json({ success: true });
   } catch (error) {
     console.error('Error al eliminar la torta:', error);
-    res.status(400).json({ error: error.message });
+    res.status(500).json({ error: error.message });
   }
 };


### PR DESCRIPTION
## Summary
- use HTTP 500 in catch blocks for ingredientes, recetas and tortas
- keep 400 only for explicit validation failures

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_687d76a8edd8832bb6e1fb88efab719f