### PR TITLE
Fix JWT verify error handling

### DIFF
--- a/controllers/ingredienteController.js
+++ b/controllers/ingredienteController.js
@@ -3,7 +3,8 @@ const { obtenerUserIdDesdeRequest } = require('../middleware/authMiddleware');
 
 exports.obtenerIngredientes = async (req, res) => {
   try {
-    const userId = obtenerUserIdDesdeRequest(req);
+    const userId = obtenerUserIdDesdeRequest(req, res);
+    if (!userId) return;
     const ingredientes = await ingredienteService.obtenerIngredientes(userId);
     res.json({ success: true, ingredientes });
   } catch (error) {
@@ -13,7 +14,8 @@ exports.obtenerIngredientes = async (req, res) => {
 
 exports.guardarIngrediente = async (req, res) => {
   try {
-    const userId = obtenerUserIdDesdeRequest(req);
+    const userId = obtenerUserIdDesdeRequest(req, res);
+    if (!userId) return;
     const { nombre, unidad_Medida, tamano_Paquete, costo, CantidadStock } = req.body;
 
     await ingredienteService.guardarIngrediente({ nombre, unidad_Medida, tamano_Paquete, costo, CantidadStock, userId });
@@ -29,7 +31,8 @@ exports.editarIngrediente = async (req, res) => {
     const { id } = req.params;
     const { nombre, unidad_Medida, tamano_Paquete, costo, CantidadStock } = req.body;
 
-    const userId = obtenerUserIdDesdeRequest(req);
+    const userId = obtenerUserIdDesdeRequest(req, res);
+    if (!userId) return;
 
     await ingredienteService.editarIngrediente({
       id,
@@ -49,7 +52,8 @@ exports.editarIngrediente = async (req, res) => {
 
 exports.obtenerIngredientesMenosStock = async (req, res) => {
   try {
-    const userId = obtenerUserIdDesdeRequest(req);
+    const userId = obtenerUserIdDesdeRequest(req, res);
+    if (!userId) return;
     const ingredientes = await ingredienteService.obtenerIngredientesMenosStock(userId);
     res.json(ingredientes);
   } catch (error) {
@@ -59,7 +63,8 @@ exports.obtenerIngredientesMenosStock = async (req, res) => {
 
 exports.eliminarIngrediente = async (req, res) => {
   try {
-    const userId = obtenerUserIdDesdeRequest(req);
+    const userId = obtenerUserIdDesdeRequest(req, res);
+    if (!userId) return;
     const { id } = req.params;
 
     await ingredienteService.eliminarIngrediente({ id, userId });

--- a/controllers/listaPreciosController.js
+++ b/controllers/listaPreciosController.js
@@ -3,22 +3,13 @@ const ListaPrecios = require('../models/ListaPrecios');
 const Receta = require('../models/Receta');
 const Torta = require('../models/Torta');
 const Ingrediente = require('../models/Ingrediente');
-const jwt = require('jsonwebtoken');
-
-const obtenerUserId = (req) => {
-  if (!req.headers.authorization || !req.headers.authorization.startsWith('Bearer ')) {
-    throw new Error('Token de autenticación no proporcionado');
-  }
-
-  const token = req.headers.authorization.split(' ')[1];
-  const decoded = jwt.verify(token, process.env.JWT_SECRET);
-  return decoded.userId;
-};
+const { obtenerUserIdDesdeRequest } = require('../middleware/authMiddleware');
 
 exports.actualizarCostoTotalReceta = async (req, res) => {
   try {
     const { idTorta } = req.body;
-    const userId = obtenerUserId(req);
+    const userId = obtenerUserIdDesdeRequest(req, res);
+    if (!userId) return;
     // console.log('ID de usuario obtenido del token:', userId);
 
     const receta = await Receta.findOne({
@@ -56,7 +47,8 @@ exports.actualizarCostoTotalReceta = async (req, res) => {
 
 exports.obtenerListaPreciosConImagen = async (req, res) => {
   try {
-    const userId = obtenerUserId(req);
+    const userId = obtenerUserIdDesdeRequest(req, res);
+    if (!userId) return;
     // console.log('Datos del usuario autenticado:', userId);
 
     const listaPrecios = await ListaPrecios.findAll({ where: { id_usuario: userId } });

--- a/controllers/recetasController.js
+++ b/controllers/recetasController.js
@@ -5,7 +5,8 @@ const { obtenerUserIdDesdeRequest } = require('../middleware/authMiddleware');
 
 exports.obtenerRecetas = async (req, res) => {
   try {
-    const userId = obtenerUserIdDesdeRequest(req);
+    const userId = obtenerUserIdDesdeRequest(req, res);
+    if (!userId) return;
     const recetas = await recetaService.obtenerRecetasPorUsuario(userId);
     res.json(recetas);
   } catch (error) {
@@ -15,7 +16,8 @@ exports.obtenerRecetas = async (req, res) => {
 
 exports.crearOEditarReceta = async (req, res) => {
   try {
-    const userId = obtenerUserIdDesdeRequest(req);
+    const userId = obtenerUserIdDesdeRequest(req, res);
+    if (!userId) return;
     const { ID_TORTA, ID_INGREDIENTE } = req.params;
     const { total_cantidad } = req.body;
 
@@ -34,7 +36,8 @@ exports.crearOEditarReceta = async (req, res) => {
 
 exports.agregarRelacion = async (req, res) => {
   try {
-    const userId = obtenerUserIdDesdeRequest(req);
+    const userId = obtenerUserIdDesdeRequest(req, res);
+    if (!userId) return;
     const { ID_TORTA, ID_INGREDIENTE, cantidad } = req.body;
 
     await recetaService.agregarRelacion({ ID_TORTA, ID_INGREDIENTE, cantidad, userId });
@@ -47,7 +50,8 @@ exports.agregarRelacion = async (req, res) => {
 
 exports.eliminarAsignacion = async (req, res) => {
   try {
-    const userId = obtenerUserIdDesdeRequest(req);
+    const userId = obtenerUserIdDesdeRequest(req, res);
+    if (!userId) return;
     const { ID_TORTA, ID_INGREDIENTE } = req.params;
 
     await recetaService.eliminarAsignacion({ ID_TORTA, ID_INGREDIENTE, userId });
@@ -60,7 +64,8 @@ exports.eliminarAsignacion = async (req, res) => {
 
 exports.eliminarReceta = async (req, res) => {
   try {
-    const userId = obtenerUserIdDesdeRequest(req);
+    const userId = obtenerUserIdDesdeRequest(req, res);
+    if (!userId) return;
     const { ID_TORTA } = req.params;
 
     await recetaService.eliminarReceta({ ID_TORTA, userId });

--- a/controllers/tortaController.js
+++ b/controllers/tortaController.js
@@ -5,7 +5,8 @@ const { obtenerUserIdDesdeRequest } = require('../middleware/authMiddleware');
 
 exports.crearTorta = async (req, res) => {
   try {
-    const userId = obtenerUserIdDesdeRequest(req);
+    const userId = obtenerUserIdDesdeRequest(req, res);
+    if (!userId) return;
     const { nombre_torta, descripcion_torta } = req.body;
     const imagen = req.file ? `uploads/${req.file.filename}` : null;
 
@@ -20,7 +21,8 @@ exports.crearTorta = async (req, res) => {
 
 exports.obtenerTortas = async (req, res) => {
   try {
-    const userId = obtenerUserIdDesdeRequest(req);
+    const userId = obtenerUserIdDesdeRequest(req, res);
+    if (!userId) return;
     const tortas = await tortaService.obtenerTortasPorUsuario(userId);
     res.json(tortas);
   } catch (error) {

--- a/controllers/ventaController.js
+++ b/controllers/ventaController.js
@@ -20,7 +20,8 @@ const getLast7DaysRange = () => {
 
 exports.obtenerVentas = async (req, res) => {
   try {
-    const userId = obtenerUserIdDesdeRequest(req);
+    const userId = obtenerUserIdDesdeRequest(req, res);
+    if (!userId) return;
     const ventas = await ventaService.obtenerVentas(userId);
     res.json(ventas);
   } catch (error) {
@@ -30,7 +31,8 @@ exports.obtenerVentas = async (req, res) => {
 
 exports.registrarVenta = async (req, res) => {
   try {
-    const userId = obtenerUserIdDesdeRequest(req);
+    const userId = obtenerUserIdDesdeRequest(req, res);
+    if (!userId) return;
     const { id_torta } = req.body;
 
     const venta = await ventaService.registrarVenta({ id_torta, userId });
@@ -42,7 +44,8 @@ exports.registrarVenta = async (req, res) => {
 
 exports.obtenerCantidadVentas = async (req, res) => {
   try {
-    const userId = obtenerUserIdDesdeRequest(req);
+    const userId = obtenerUserIdDesdeRequest(req, res);
+    if (!userId) return;
     const cantidad = await ventaService.obtenerCantidadVentas(userId);
     res.json({ cantidadVentas: cantidad });
   } catch (error) {
@@ -52,7 +55,8 @@ exports.obtenerCantidadVentas = async (req, res) => {
 
 exports.obtenerCantidadVentasSemana = async (req, res) => {
   try {
-    const userId = obtenerUserIdDesdeRequest(req);
+    const userId = obtenerUserIdDesdeRequest(req, res);
+    if (!userId) return;
     const { current } = getLast7DaysRange();
     const cantidad = await ventaService.obtenerCantidadVentasSemana(userId, current);
     res.json({ cantidadVentas: cantidad });
@@ -63,7 +67,8 @@ exports.obtenerCantidadVentasSemana = async (req, res) => {
 
 exports.obtenerGanancias = async (req, res) => {
   try {
-    const userId = obtenerUserIdDesdeRequest(req);
+    const userId = obtenerUserIdDesdeRequest(req, res);
+    if (!userId) return;
     const ganancias = await ventaService.obtenerGanancias(userId);
     res.json({ ganancias });
   } catch (error) {
@@ -73,7 +78,8 @@ exports.obtenerGanancias = async (req, res) => {
 
 exports.obtenerPorcentajeVentas = async (req, res) => {
   try {
-    const userId = obtenerUserIdDesdeRequest(req);
+    const userId = obtenerUserIdDesdeRequest(req, res);
+    if (!userId) return;
     const { current, last } = getLast7DaysRange();
     const datos = await ventaService.obtenerPorcentajeVentas(userId, current, last);
 

--- a/middleware/authMiddleware.js
+++ b/middleware/authMiddleware.js
@@ -3,11 +3,23 @@
 const jwt = require('jsonwebtoken');
 require('dotenv').config();
 
-exports.obtenerUserIdDesdeRequest = (req) => {
+exports.obtenerUserIdDesdeRequest = (req, res) => {
   if (!req.headers.authorization || !req.headers.authorization.startsWith('Bearer ')) {
-    throw new Error('Token de autenticación no proporcionado');
+    if (res) {
+      res.status(401).json({ error: 'Token de autenticación no proporcionado' });
+    }
+    return null;
   }
+
   const token = req.headers.authorization.split(' ')[1];
-  const decoded = jwt.verify(token, process.env.JWT_SECRET);
-  return decoded.userId;
+
+  try {
+    const decoded = jwt.verify(token, process.env.JWT_SECRET);
+    return decoded.userId;
+  } catch (error) {
+    if (res) {
+      res.status(401).json({ error: 'Token de autenticación inválido' });
+    }
+    return null;
+  }
 };


### PR DESCRIPTION
## Summary
- wrap `jwt.verify` with a try-catch in `authMiddleware`
- send a 401 Unauthorized response when authentication fails
- rely on the middleware from controllers

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_687d76a7b84c832b8d268f08f03f3532