### PR TITLE
Protect user listing with auth and sanitized fields

### DIFF
--- a/controllers/userController.js
+++ b/controllers/userController.js
@@ -27,7 +27,8 @@ exports.createUser = async (req, res) => {
 exports.getUsers = async (req, res) => {
   try {
     const users = await userService.getUsers();
-    res.json(users);
+    const safeUsers = users.map(({ id, nombre, email }) => ({ id, nombre, email }));
+    res.json(safeUsers);
   } catch (error) {
     res.status(500).json({ error: 'Error al obtener usuarios' });
   }

--- a/routes/users.js
+++ b/routes/users.js
@@ -1,13 +1,21 @@
 const express = require('express');
 const router = express.Router();
 const { createUser, getUsers, requestPasswordReset, resetPassword } = require('../controllers/userController');
+const { obtenerUserIdDesdeRequest } = require('../middleware/authMiddleware');
+
+// Middleware sencillo para exigir autenticación
+const requireAuth = (req, res, next) => {
+  const userId = obtenerUserIdDesdeRequest(req, res);
+  if (!userId) return;
+  req.userId = userId;
+  next();
+};
 
 // Define las rutas usando las funciones importadas directamente
-router.get('/', getUsers);
+router.get('/', requireAuth, getUsers);
 router.post('/register', createUser);
 
 router.post('/request-password-reset', requestPasswordReset);
 router.post('/reset-password', resetPassword);
-
 
 module.exports = router;


### PR DESCRIPTION
## Summary
- enforce token verification before listing users
- avoid exposing sensitive user fields

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688fc8c81c40832b876e41b6a2caecda