### PR TITLE
centralize environment configuration

### DIFF
--- a/config/env.js
+++ b/config/env.js
@@ -1,0 +1,1 @@
+require('dotenv').config();

--- a/controllers/loginController.js
+++ b/controllers/loginController.js
@@ -1,7 +1,7 @@
 const bcrypt = require('bcrypt');
 const jwt = require('jsonwebtoken');
 const User = require('../models/User');
-require('dotenv').config();
+require('../config/env');
 
 // Clave secreta para firmar el token
 const secretKey = process.env.JWT_SECRET;

--- a/database/connection.js
+++ b/database/connection.js
@@ -1,5 +1,5 @@
 const { Sequelize } = require('sequelize');
-require('dotenv').config();
+require('../config/env');
 console.log("💡 DB_NAME ACTUAL:", process.env.DB_NAME);
 
 

--- a/middleware/authMiddleware.js
+++ b/middleware/authMiddleware.js
@@ -1,7 +1,7 @@
 // middlewares/authMiddleware.js
 
 const jwt = require('jsonwebtoken');
-require('dotenv').config();
+require('../config/env');
 
 exports.obtenerUserIdDesdeRequest = (req, res) => {
   if (!req.headers.authorization || !req.headers.authorization.startsWith('Bearer ')) {

--- a/models/index.js
+++ b/models/index.js
@@ -6,7 +6,7 @@ const Sequelize = require('sequelize');
 const process = require('process');
 const basename = path.basename(__filename);
 const env = process.env.NODE_ENV || 'development';
-require('dotenv').config();
+require('../config/env');
 const config = require(__dirname + '/../config/config.js')[env];
 const db = {};
 

--- a/server.js
+++ b/server.js
@@ -1,7 +1,7 @@
 const express = require('express');
 const cors = require('cors');
 const app = express();
-require('dotenv').config();
+require('./config/env');
 const db = require('./database/connection');
 const path = require('path');
 const { actualizarListaPrecios, calcularCostoTotalReceta } = require('./services/calculadoraCostos');

--- a/services/userService.js
+++ b/services/userService.js
@@ -3,7 +3,7 @@ const jwt = require('jsonwebtoken');
 const User = require('../models/User');
 const Ingrediente = require('../models/Ingrediente');
 const nodemailer = require('nodemailer');
-require('dotenv').config();
+require('../config/env');
 
 const JWT_SECRET = process.env.JWT_SECRET;
 const RESET_SECRET_KEY = process.env.RESET_SECRET_KEY || JWT_SECRET;


### PR DESCRIPTION
## Summary
- centralize dotenv loading in config/env
- remove redundant dotenv calls across modules

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688fcefe9e3c832b895f70afeef19c44