### PR TITLE
Centralize error handling

### DIFF
--- a/controllers/ingredienteController.js
+++ b/controllers/ingredienteController.js
@@ -1,19 +1,18 @@
 const ingredienteService = require('../services/ingredienteService');
 const { obtenerUserIdDesdeRequest } = require('../middleware/authMiddleware');
 
-exports.obtenerIngredientes = async (req, res) => {
+exports.obtenerIngredientes = async (req, res, next) => {
   try {
     const userId = obtenerUserIdDesdeRequest(req, res);
     if (!userId) return;
     const ingredientes = await ingredienteService.obtenerIngredientes(userId);
     res.json({ success: true, ingredientes });
   } catch (error) {
-    console.error(error);
-    res.status(500).json({ error: 'Server error' });
+    next(error);
   }
 };
 
-exports.guardarIngrediente = async (req, res) => {
+exports.guardarIngrediente = async (req, res, next) => {
   try {
     const userId = obtenerUserIdDesdeRequest(req, res);
     if (!userId) return;
@@ -23,12 +22,11 @@ exports.guardarIngrediente = async (req, res) => {
 
     res.json({ success: true });
   } catch (error) {
-    console.error(error);
-    res.status(500).json({ error: 'Server error' });
+    next(error);
   }
 };
 
-exports.editarIngrediente = async (req, res) => {
+exports.editarIngrediente = async (req, res, next) => {
   try {
     const { id } = req.params;
     const { nombre, unidad_Medida, tamano_Paquete, costo, CantidadStock } = req.body;
@@ -48,24 +46,22 @@ exports.editarIngrediente = async (req, res) => {
 
     res.json({ success: true });
   } catch (error) {
-    console.error(error);
-    res.status(500).json({ error: 'Server error' });
+    next(error);
   }
 };
 
-exports.obtenerIngredientesMenosStock = async (req, res) => {
+exports.obtenerIngredientesMenosStock = async (req, res, next) => {
   try {
     const userId = obtenerUserIdDesdeRequest(req, res);
     if (!userId) return;
     const ingredientes = await ingredienteService.obtenerIngredientesMenosStock(userId);
     res.json(ingredientes);
   } catch (error) {
-    console.error(error);
-    res.status(500).json({ error: 'Server error' });
+    next(error);
   }
 };
 
-exports.eliminarIngrediente = async (req, res) => {
+exports.eliminarIngrediente = async (req, res, next) => {
   try {
     const userId = obtenerUserIdDesdeRequest(req, res);
     if (!userId) return;
@@ -75,7 +71,6 @@ exports.eliminarIngrediente = async (req, res) => {
 
     res.json({ success: true });
   } catch (error) {
-    console.error(error);
-    res.status(500).json({ error: 'Server error' });
+    next(error);
   }
 };

--- a/controllers/listaPreciosController.js
+++ b/controllers/listaPreciosController.js
@@ -9,61 +9,45 @@ const { obtenerUserIdDesdeRequest } = require('../middleware/authMiddleware');
 
 
 
-exports.actualizarCostoTotalReceta = async (req, res) => {
+exports.actualizarCostoTotalReceta = async (req, res, next) => {
   try {
     const { idTorta } = req.body;
     const userId = obtenerUserIdDesdeRequest(req, res);
     if (!userId) return;
-    // console.log('ID de usuario obtenido del token:', userId);
 
     const receta = await Receta.findOne({
       where: { ID_TORTA: idTorta, id_usuario: userId }
     });
-    // console.log('Receta encontrada:', receta);
 
     if (!receta) {
       throw new Error('No se encontró la receta');
     }
 
     const costoTotal = await calcularCostoTotalReceta(idTorta, userId);
-    // console.log('Costo total calculado:', costoTotal);
-    /* console.log('Datos a guardar en ListaPrecios:', {
-      id_torta: receta.ID_TORTA,
-      nombre_torta: receta.nombre_torta,
-      costo_total: costoTotal,
-      id_usuario: userId
-    }); */
 
-    const result = await ListaPrecios.upsert({
+    await ListaPrecios.upsert({
       id_torta: receta.ID_TORTA,
       nombre_torta: receta.nombre_torta,
       costo_total: costoTotal,
       id_usuario: userId
     });
-    // console.log('Resultado de upsert en ListaPrecios:', result);
 
     res.status(200).json({ message: 'Costo total de la receta actualizado correctamente' });
   } catch (error) {
-    console.error('Error al actualizar el costo total de la receta:', error);
-    res.status(500).json({ error: 'Error al actualizar el costo total de la receta' });
+    next(error);
   }
 };
 
-exports.obtenerListaPreciosConImagen = async (req, res) => {
+exports.obtenerListaPreciosConImagen = async (req, res, next) => {
   try {
     const userId = obtenerUserIdDesdeRequest(req, res);
     if (!userId) return;
-    // console.log('Datos del usuario autenticado:', userId);
 
     const listaPrecios = await ListaPrecios.findAll({ where: { id_usuario: userId } });
 
-
     const listaPreciosConImagen = await Promise.all(listaPrecios.map(async (item) => {
-      
-      
       const torta = await Torta.findOne({ where: { ID_TORTA: item.id_torta } });
-  
-      
+
       return {
         ...item.toJSON(),
         imagen_torta: torta.imagen
@@ -72,7 +56,6 @@ exports.obtenerListaPreciosConImagen = async (req, res) => {
 
     res.json(listaPreciosConImagen);
   } catch (error) {
-    console.error('Error al obtener la lista de precios con imagen:', error);
-    res.status(500).json({ error: 'Error al obtener la lista de precios con imagen' });
+    next(error);
   }
 };

--- a/controllers/loginController.js
+++ b/controllers/loginController.js
@@ -6,7 +6,7 @@ require('../config/env');
 // Clave secreta para firmar el token
 const secretKey = process.env.JWT_SECRET;
 
-exports.loginUser = async (req, res) => {
+exports.loginUser = async (req, res, next) => {
   const { email, contrasena } = req.body;
   // console.log('Intentando iniciar sesión con:', req.body);
 
@@ -32,7 +32,6 @@ exports.loginUser = async (req, res) => {
 
     res.json({ success: true, token });
   } catch (error) {
-    console.error('Error al iniciar sesión:', error);
-    res.status(500).json({ error: 'Error al iniciar sesión' });
+    next(error);
   }
 };

--- a/controllers/recetasController.js
+++ b/controllers/recetasController.js
@@ -3,19 +3,18 @@
 const recetaService = require('../services/recetaServices');
 const { obtenerUserIdDesdeRequest } = require('../middleware/authMiddleware');
 
-exports.obtenerRecetas = async (req, res) => {
+exports.obtenerRecetas = async (req, res, next) => {
   try {
     const userId = obtenerUserIdDesdeRequest(req, res);
     if (!userId) return;
     const recetas = await recetaService.obtenerRecetasPorUsuario(userId);
     res.json(recetas);
   } catch (error) {
-    console.error(error);
-    res.status(500).json({ error: 'Server error' });
+    next(error);
   }
 };
 
-exports.crearOEditarReceta = async (req, res) => {
+exports.crearOEditarReceta = async (req, res, next) => {
   try {
     const userId = obtenerUserIdDesdeRequest(req, res);
     if (!userId) return;
@@ -31,12 +30,11 @@ exports.crearOEditarReceta = async (req, res) => {
 
     res.json({ success: true });
   } catch (error) {
-    console.error(error);
-    res.status(500).json({ error: 'Server error' });
+    next(error);
   }
 };
 
-exports.agregarRelacion = async (req, res) => {
+exports.agregarRelacion = async (req, res, next) => {
   try {
     const userId = obtenerUserIdDesdeRequest(req, res);
     if (!userId) return;
@@ -46,12 +44,11 @@ exports.agregarRelacion = async (req, res) => {
 
     res.json({ message: 'Nueva relación agregada exitosamente' });
   } catch (error) {
-    console.error(error);
-    res.status(500).json({ error: 'Server error' });
+    next(error);
   }
 };
 
-exports.eliminarAsignacion = async (req, res) => {
+exports.eliminarAsignacion = async (req, res, next) => {
   try {
     const userId = obtenerUserIdDesdeRequest(req, res);
     if (!userId) return;
@@ -61,12 +58,11 @@ exports.eliminarAsignacion = async (req, res) => {
 
     res.json({ message: 'Asignación de receta eliminada exitosamente' });
   } catch (error) {
-    console.error(error);
-    res.status(500).json({ error: 'Server error' });
+    next(error);
   }
 };
 
-exports.eliminarReceta = async (req, res) => {
+exports.eliminarReceta = async (req, res, next) => {
   try {
     const userId = obtenerUserIdDesdeRequest(req, res);
     if (!userId) return;
@@ -76,8 +72,7 @@ exports.eliminarReceta = async (req, res) => {
 
     res.json({ message: 'Receta eliminada exitosamente' });
   } catch (error) {
-    console.error(error);
-    res.status(500).json({ error: 'Server error' });
+    next(error);
   }
 };
 

--- a/controllers/tortaController.js
+++ b/controllers/tortaController.js
@@ -3,7 +3,7 @@
 const tortaService = require('../services/tortaService');
 const { obtenerUserIdDesdeRequest } = require('../middleware/authMiddleware');
 
-exports.crearTorta = async (req, res) => {
+exports.crearTorta = async (req, res, next) => {
   try {
     const userId = obtenerUserIdDesdeRequest(req, res);
     if (!userId) return;
@@ -14,24 +14,22 @@ exports.crearTorta = async (req, res) => {
 
     res.json({ success: true, torta });
   } catch (error) {
-    console.error('Error al crear la torta:', error);
-    res.status(500).json({ error: 'Server error' });
+    next(error);
   }
 };
 
-exports.obtenerTortas = async (req, res) => {
+exports.obtenerTortas = async (req, res, next) => {
   try {
     const userId = obtenerUserIdDesdeRequest(req, res);
     if (!userId) return;
     const tortas = await tortaService.obtenerTortasPorUsuario(userId);
     res.json(tortas);
   } catch (error) {
-    console.error(error);
-    res.status(500).json({ error: 'Server error' });
+    next(error);
   }
 };
 
-exports.obtenerTortasConPrecios = async (req, res) => {
+exports.obtenerTortasConPrecios = async (req, res, next) => {
   try {
     const userId = obtenerUserIdDesdeRequest(req, res);
     if (!userId) return;
@@ -39,12 +37,11 @@ exports.obtenerTortasConPrecios = async (req, res) => {
     const tortasConPrecio = await tortaService.obtenerTortasConPrecioPorUsuario(userId);
     res.json(tortasConPrecio);
   } catch (error) {
-    console.error('Error al obtener las tortas con precio:', error);
-    res.status(500).json({ error: 'Error al obtener las tortas con precio' });
+    next(error);
   }
 };
 
-exports.editarTorta = async (req, res) => {
+exports.editarTorta = async (req, res, next) => {
   try {
     const userId = obtenerUserIdDesdeRequest(req, res);
     if (!userId) return;
@@ -56,18 +53,11 @@ exports.editarTorta = async (req, res) => {
 
     res.json({ success: true, torta });
   } catch (error) {
-    if (error.status === 403) {
-      return res.status(403).json({ error: 'Torta no pertenece al usuario' });
-    }
-    if (error.status === 404) {
-      return res.status(404).json({ error: 'Torta no encontrada' });
-    }
-    console.error('Error al editar la torta:', error);
-    res.status(500).json({ error: 'Server error' });
+    next(error);
   }
 };
 
-exports.eliminarTorta = async (req, res) => {
+exports.eliminarTorta = async (req, res, next) => {
   try {
     const userId = obtenerUserIdDesdeRequest(req, res);
     if (!userId) return;
@@ -77,13 +67,6 @@ exports.eliminarTorta = async (req, res) => {
 
     res.json({ success: true });
   } catch (error) {
-    if (error.status === 403) {
-      return res.status(403).json({ error: 'Torta no pertenece al usuario' });
-    }
-    if (error.status === 404) {
-      return res.status(404).json({ error: 'Torta no encontrada' });
-    }
-    console.error('Error al eliminar la torta:', error);
-    res.status(500).json({ error: 'Server error' });
+    next(error);
   }
 };

--- a/controllers/userController.js
+++ b/controllers/userController.js
@@ -1,6 +1,6 @@
 const userService = require('../services/userService');
 
-exports.loginUser = async (req, res) => {
+exports.loginUser = async (req, res, next) => {
   const { email, contrasena } = req.body;
   if (!email || !contrasena) return res.status(400).json({ error: 'Faltan datos' });
 
@@ -8,11 +8,12 @@ exports.loginUser = async (req, res) => {
     const token = await userService.loginUser({ email, contrasena });
     res.json({ success: true, token });
   } catch (error) {
-    res.status(401).json({ error: error.message });
+    error.status = 401;
+    next(error);
   }
 };
 
-exports.createUser = async (req, res) => {
+exports.createUser = async (req, res, next) => {
   const { nombre, email, contrasena } = req.body;
   if (!nombre || !email || !contrasena) return res.status(400).json({ error: 'Faltan datos' });
 
@@ -20,21 +21,21 @@ exports.createUser = async (req, res) => {
     const user = await userService.createUser({ nombre, email, contrasena });
     res.json({ success: true, user });
   } catch (error) {
-    res.status(500).json({ error: 'Error al crear el usuario' });
+    next(error);
   }
 };
 
-exports.getUsers = async (req, res) => {
+exports.getUsers = async (req, res, next) => {
   try {
     const users = await userService.getUsers();
     const safeUsers = users.map(({ id, nombre, email }) => ({ id, nombre, email }));
     res.json(safeUsers);
   } catch (error) {
-    res.status(500).json({ error: 'Error al obtener usuarios' });
+    next(error);
   }
 };
 
-exports.requestPasswordReset = async (req, res) => {
+exports.requestPasswordReset = async (req, res, next) => {
   const { email } = req.body;
   if (!email) return res.status(400).json({ error: 'Email es requerido' });
 
@@ -42,12 +43,11 @@ exports.requestPasswordReset = async (req, res) => {
     await userService.requestPasswordReset(email);
     res.json({ success: true, message: 'Correo enviado' });
   } catch (error) {
-    console.error(error);
-    res.status(500).json({ error: 'Server error' });
+    next(error);
   }
 };
 
-exports.resetPassword = async (req, res) => {
+exports.resetPassword = async (req, res, next) => {
   const { token, newPassword } = req.body;
   if (!token || !newPassword) return res.status(400).json({ error: 'Faltan datos' });
 
@@ -55,7 +55,6 @@ exports.resetPassword = async (req, res) => {
     await userService.resetPassword(token, newPassword);
     res.json({ success: true, message: 'Contraseña restablecida' });
   } catch (error) {
-    console.error(error);
-    res.status(500).json({ error: 'Server error' });
+    next(error);
   }
 };

--- a/controllers/ventaController.js
+++ b/controllers/ventaController.js
@@ -18,19 +18,18 @@ const getLast7DaysRange = () => {
   return { current: { start: currentStart, end: currentEnd }, last: { start: lastPeriodStart, end: lastPeriodEnd } };
 };
 
-exports.obtenerVentas = async (req, res) => {
+exports.obtenerVentas = async (req, res, next) => {
   try {
     const userId = obtenerUserIdDesdeRequest(req, res);
     if (!userId) return;
     const ventas = await ventaService.obtenerVentas(userId);
     res.json(ventas);
   } catch (error) {
-    console.error(error);
-    res.status(500).json({ error: 'Server error' });
+    next(error);
   }
 };
 
-exports.registrarVenta = async (req, res) => {
+exports.registrarVenta = async (req, res, next) => {
   try {
     const userId = obtenerUserIdDesdeRequest(req, res);
     if (!userId) return;
@@ -39,24 +38,22 @@ exports.registrarVenta = async (req, res) => {
     const venta = await ventaService.registrarVenta({ id_torta, userId });
     res.json({ success: true, venta });
   } catch (error) {
-    console.error(error);
-    res.status(500).json({ success: false, error: 'Server error' });
+    next(error);
   }
 };
 
-exports.obtenerCantidadVentas = async (req, res) => {
+exports.obtenerCantidadVentas = async (req, res, next) => {
   try {
     const userId = obtenerUserIdDesdeRequest(req, res);
     if (!userId) return;
     const cantidad = await ventaService.obtenerCantidadVentas(userId);
     res.json({ cantidadVentas: cantidad });
   } catch (error) {
-    console.error(error);
-    res.status(500).json({ error: 'Server error' });
+    next(error);
   }
 };
 
-exports.obtenerCantidadVentasSemana = async (req, res) => {
+exports.obtenerCantidadVentasSemana = async (req, res, next) => {
   try {
     const userId = obtenerUserIdDesdeRequest(req, res);
     if (!userId) return;
@@ -64,24 +61,22 @@ exports.obtenerCantidadVentasSemana = async (req, res) => {
     const cantidad = await ventaService.obtenerCantidadVentasSemana(userId, current);
     res.json({ cantidadVentas: cantidad });
   } catch (error) {
-    console.error(error);
-    res.status(500).json({ error: 'Server error' });
+    next(error);
   }
 };
 
-exports.obtenerGanancias = async (req, res) => {
+exports.obtenerGanancias = async (req, res, next) => {
   try {
     const userId = obtenerUserIdDesdeRequest(req, res);
     if (!userId) return;
     const ganancias = await ventaService.obtenerGanancias(userId);
     res.json({ ganancias });
   } catch (error) {
-    console.error(error);
-    res.status(500).json({ error: 'Server error' });
+    next(error);
   }
 };
 
-exports.obtenerPorcentajeVentas = async (req, res) => {
+exports.obtenerPorcentajeVentas = async (req, res, next) => {
   try {
     const userId = obtenerUserIdDesdeRequest(req, res);
     if (!userId) return;
@@ -98,7 +93,6 @@ exports.obtenerPorcentajeVentas = async (req, res) => {
       }
     });
   } catch (error) {
-    console.error(error);
-    res.status(500).json({ error: 'Server error' });
+    next(error);
   }
 };

--- a/middleware/errorHandler.js
+++ b/middleware/errorHandler.js
@@ -1,0 +1,6 @@
+module.exports = (err, req, res, next) => {
+  console.error(err);
+  const status = err.status || 500;
+  const message = err.message || 'Server error';
+  res.status(status).json({ error: message });
+};

--- a/server.js
+++ b/server.js
@@ -44,6 +44,7 @@ const listaPreciosRoutes = require('./routes/lista_precios');
 const ventasRoutes = require('./routes/ventas');
 const userRoutes = require('./routes/users');
 const loginRoutes = require('./routes/login');
+const errorHandler = require('./middleware/errorHandler');
 
 // Configurar rutas
 app.use('/ventas', ventasRoutes);
@@ -56,6 +57,9 @@ app.use('/lista_precios', listaPreciosRoutes);
 
 // Servir archivos estáticos
 app.use('/uploads', express.static(path.join(__dirname, 'uploads')));
+
+// Manejo de errores
+app.use(errorHandler);
 
 // Puerto del servidor
 const PORT = process.env.PORT || 3010;


### PR DESCRIPTION
## Summary
- add shared `errorHandler` middleware
- route handlers call `next(err)` instead of replying directly
- plug middleware into Express server

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688fd270f08c832bbee64ca07f7f3059