### PR TITLE
Restrict default CORS origin

### DIFF
--- a/server.js
+++ b/server.js
@@ -11,13 +11,19 @@ db.authenticate().catch((error) => {
 });
 
 // ******************************
-// CONFIGURACIÓN CORS ABIERTA (SOLO PARA DESARROLLO)
+// CONFIGURACIÓN CORS
 // ******************************
 
 
 
-// Leer origen permitido desde variable de entorno, por defecto abierto
-const corsOrigin = process.env.CORS_ORIGIN || '*';
+// Leer origen permitido desde variable de entorno, por defecto http://localhost:3000
+const corsOrigin = process.env.CORS_ORIGIN || 'http://localhost:3000';
+
+if (corsOrigin === '*') {
+  console.warn(
+    "Advertencia: CORS configurado con origen abierto ('*'). Esto solo debe usarse en desarrollo."
+  );
+}
 
 const corsOptions = {
     origin: corsOrigin,


### PR DESCRIPTION
## Summary
- default CORS origin now http://localhost:3000 when CORS_ORIGIN not provided
- warn developers when wildcard CORS origin is used

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6890049169f0832b9ccd5a847a70dc12