### PR TITLE
feat: allow configurable db name logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ El servidor utiliza variables de entorno que pueden declararse en un archivo `.e
 
 - `CORS_ORIGIN`: origen permitido para las solicitudes CORS. Si no se define, se permite cualquier origen (útil para desarrollo).
 - `PORT`: puerto en el que se ejecuta el servidor. Por defecto `3001`.
+- `LOG_DB_NAME`: si se establece en `true`, muestra en consola el nombre de la base de datos utilizada.
 
 Ejemplo de archivo `.env`:
 
@@ -19,6 +20,7 @@ DB_PORT=3306
 DB_USER=root
 DB_PASS=tu_contrasena
 DB_NAME=costo_smart
+LOG_DB_NAME=false
 ```
 
 ## Uso

--- a/database/connection.js
+++ b/database/connection.js
@@ -1,6 +1,9 @@
 const { Sequelize } = require('sequelize');
 require('../config/env');
-console.log("💡 DB_NAME ACTUAL:", process.env.DB_NAME);
+
+if (process.env.LOG_DB_NAME === 'true') {
+  console.log('💡 DB_NAME ACTUAL:', process.env.DB_NAME);
+}
 
 
 const db = new Sequelize(


### PR DESCRIPTION
## Summary
- log current DB name only when LOG_DB_NAME env var is true
- document LOG_DB_NAME environment variable in README

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6890064ab43c832b9ec19990e8459f96